### PR TITLE
Revert "Fix mouseleave behavior"

### DIFF
--- a/public/app/panels/graph/graph.tooltip.js
+++ b/public/app/panels/graph/graph.tooltip.js
@@ -95,7 +95,7 @@ function ($) {
     });
 
     elem.mouseleave(function () {
-      tooltipFrozen = false;
+      if (tooltipFrozen) return;
 
       if (scope.panel.tooltip.shared) {
         var plot = elem.data().plot;


### PR DESCRIPTION
Reverts lyft/grafana#8

`mouseleave` is triggered on leaving the series.
